### PR TITLE
Feature/add channel restrictions & deployment advice

### DIFF
--- a/docs/guides/voyage/voyage.md
+++ b/docs/guides/voyage/voyage.md
@@ -125,7 +125,7 @@ Voyages have specific requirements, milestones, and ***require a commitment of 8
   
   [When2Meet](https://when2meet.com/)
   
-  [How to Create a When2Meet Link (gif)](https://gfycat.com/minoryawningbasil)
+  [How to Create a When2Meet Link (gif)](./assets/How_to_use_when2meet.gif)
     
   ---
   #### 2. Conduct kickoff meeting

--- a/docs/guides/voyage/voyage.md
+++ b/docs/guides/voyage/voyage.md
@@ -322,7 +322,7 @@ Voyages have specific requirements, milestones, and ***require a commitment of 8
   
   [When2Meet website](https://when2meet.com/)
   
-  [How to Create a When2Meet link (gif)](./assets/How_to_use_when2meet.gif)
+  [How to Create a When2Meet Link (gif)](./assets/How_to_use_when2meet.gif)
   
   [Meeting template - Sprint Review, Retrospective, & Planning](https://docs.google.com/document/d/1N0rMPGzjR2kPJrMOBKJMUmTx8KCMejJ46pQSRqzHckk/edit?usp=sharing) ^
   

--- a/docs/guides/voyage/voyage.md
+++ b/docs/guides/voyage/voyage.md
@@ -101,7 +101,8 @@ When your Voyage starts you will see that we have provided your team with your
 own team channel in Discord. You should use this to communicate and collaborate
 with one another on your project. Access to this channel is restricted to your
 team so it's the best place for open, frank, and respectful communication with
-your teammates. **_You must not create your own team channel_**
+your teammates. **_Your team must not create your own Discord server, 
+Slack channel, etc. to communicate in with each other about your project._**
 
 You will also be provided with a GitHub repo in the `chingu-voyages` 
 organization for your project code. Everyone on your team will have `admin`


### PR DESCRIPTION
- Add restrictions on teams creating their own channels or repos to be more clear about what is required
- Add advice on which branches to deploy from and the need to deploy in each sprint. This comes from a suggest made during the Roundtable meeting on 2023-10-04.