### PR TITLE
Fix Issue #53 - Add soloproject folder to soloproject link path

### DIFF
--- a/docs/gettingstarted/programs.md
+++ b/docs/gettingstarted/programs.md
@@ -22,4 +22,4 @@ an app like [Chingu Quiz](https://github.com/chingu-voyages/moonshot-chingu-qui
 
 Voyages, Pair Programming, and Moonshots are open to all Chingus. You can apply 
 to take part in these once you've [applied to join Chingu](https://chingu.io/) 
-and completed your [Solo Project](../guides/soloproject.md).
+and completed your [Solo Project](../guides/soloproject/soloproject.md).


### PR DESCRIPTION
The link to the Solo Project Guide on the Programs & Services guide needed the folder name 'solo project' added to the path. 

Fixes #53 