### PR TITLE
Feature/update solo flow diagram

### DIFF
--- a/docs/guides/soloproject/soloproject.md
+++ b/docs/guides/soloproject/soloproject.md
@@ -21,7 +21,7 @@ graph LR
     B -- Scrum Master or UI/UX Designer --> G
     B -- Product Owner\nDeveloper\nData Scientist --> F{Do you have a project?}
     F -- Yes --> G[Submit your\nSolo Project]
-    F -- No --> H[Create new\nSolo Project\matching your tier]
+    F -- No --> H[Create new\nSolo Project\nmatching your tier]
     H --> G
     G --> I[Facilitator\ngives feedback]
     I --> J((Signup for\na Voyage))

--- a/docs/guides/soloproject/soloproject.md
+++ b/docs/guides/soloproject/soloproject.md
@@ -21,7 +21,7 @@ graph LR
     B -- Scrum Master or UI/UX Designer --> G
     B -- Product Owner\nDeveloper\nData Scientist --> F{Do you have a project?}
     F -- Yes --> G[Submit your\nSolo Project]
-    F -- No --> H[Create from\nChingu Specs]
+    F -- No --> H[Create new\nSolo Project\matching your tier]
     H --> G
     G --> I[Facilitator\ngives feedback]
     I --> J((Signup for\na Voyage))


### PR DESCRIPTION
Remove the reference to creating a new Solo Project based on Chingu Specifications from the Solo Project flow diagram. Chingus must now choose their own.