### PR TITLE
Feature: Change the voyage guide section to voyage manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ flowchart TB
 
 ### Program Guides
 
-- [Solo Project Guide](./docs/guides/soloproject/soloproject.md)
-- [Voyage Manual](./docs/guides/voyage/voyage.md)
+- [Solo Project](./docs/guides/soloproject/soloproject.md)
+- [Voyage](./docs/guides/voyage/voyage.md)
 - [Pair Programming Guide](./docs/guides/pairprog/pairprog.md)
 - [Handbook Contributors Guide](./docs/guides/contributors/contributors.md)
 - [Content Creators Guide](./docs/guides/contentcreator/contentcreator.md)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ flowchart TB
 ### Program Guides
 
 - [Solo Project Guide](./docs/guides/soloproject/soloproject.md)
-- [Voyage Guide](./docs/guides/voyage/voyage.md)
+- [Voyage Manual](./docs/guides/voyage/voyage.md)
 - [Pair Programming Guide](./docs/guides/pairprog/pairprog.md)
 - [Handbook Contributors Guide](./docs/guides/contributors/contributors.md)
 - [Content Creators Guide](./docs/guides/contentcreator/contentcreator.md)

--- a/docs/guides/soloproject/soloproject.md
+++ b/docs/guides/soloproject/soloproject.md
@@ -1,4 +1,4 @@
-# Solo Project Guide
+# Solo Project
 
 ![Team creating project backlog](./assets/SoloProject_coder.jpeg)
 

--- a/docs/guides/voyage/voyage.md
+++ b/docs/guides/voyage/voyage.md
@@ -1,4 +1,4 @@
-# Voyage Guide
+# Voyage Manual
 
 ![Team creating product backlog](./assets/Team_creating_agile_backlog_board.jpeg)
 

--- a/docs/guides/voyage/voyage.md
+++ b/docs/guides/voyage/voyage.md
@@ -1,4 +1,4 @@
-# Voyage Manual
+# Voyage
 
 ![Team creating product backlog](./assets/Team_creating_agile_backlog_board.jpeg)
 


### PR DESCRIPTION
I personally find a bit confusing having a role and a section from the Handbook called the same as it is the case of the `voyage guide`.

That is the reason that I'm proposing the change of the section title from **Voyage Guide** to **Voyage Manual** that way will be more clear what someone is referencing to when mentioning either voyage guide or voyage manual.

I am open to change the title to something else that may be more descriptive 