### PR TITLE
docs(readme): fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the governance of Chingu.
 ```mermaid
 flowchart TB
    A(Have you completed a Voyage?) -- No --> B(<a href='https://github.com/chingu-voyages/Handbook/blob/main/docs/guides/soloproject/soloproject.md#1-choose-your-tier-1%EF%B8%8F%E2%83%A3-2%EF%B8%8F%E2%83%A3-3%EF%B8%8F%E2%83%A3' target='_blank'>Choose your tier</a>);
-   A -- Yes --> C(Learn more about <a href='https://github.com/chingu-voyages/Handbook/blob/feature/add-voyagexp/docs/guides/voyagexp/voyagexp.md' target='_blank'>VoyageXP</a>);
+   A -- Yes --> C(Learn more about <a href='https://github.com/chingu-voyages/Handbook/blob/main/docs/guides/voyagexp/voyagexp.md' target='_blank'>VoyageXP</a>);
    C --> Z([End]);
    B --> D(Submit an original</br><a href='https://github.com/chingu-voyages/Handbook/blob/main/docs/guides/soloproject/soloproject.md' target='_blank'>Solo Project</a> for evaluation);
    D --> E(Evaluator DMs</br>feedback in Discord);


### PR DESCRIPTION
This pull request fixes an incorrect link in the README.md file. The VoyageXP link in the Mermaid flowchart was pointing to a feature branch instead of the main branch.

Changed:

From: feature/add-voyagexp branch
To: main branch
The link now correctly directs to: https://github.com/chingu-voyages/Handbook/blob/main/docs/guides/voyagexp/voyagexp.md

Why this matters:
The previous link could break if the feature branch is deleted. By pointing to main, the documentation link will always be stable and up-to-date.